### PR TITLE
Cleanup non en-US locales after unpack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,20 +30,22 @@ jobs:
       - name: ⏬ download
         run: |
           mkdir obj
-          
+          shopt -s extglob
+
           curl https://download-chromium.appspot.com/dl/Win_x64?type=snapshots -L -o obj/win-x64.zip
           unzip -o obj/win-x64.zip -d src/chromium.win-x64
-          rm ./src/chromium.win-x64/chrome-win/interactive_ui_tests.exe
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Win_x64?type=snapshots | grep -oP "\d{6,}") > src/chromium.win-x64/readme.md
 
           curl https://download-chromium.appspot.com/dl/Win?type=snapshots -L -o obj/win-x86.zip
           unzip -o obj/win-x86.zip -d src/chromium.win-x86
-          rm ./src/chromium.win-x86/chrome-win/interactive_ui_tests.exe
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Win?type=snapshots | grep -oP "\d{6,}") > src/chromium.win-x86/readme.md
 
           curl https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots -L -o obj/linux-x64.zip
           unzip -o obj/linux-x64.zip -d src/chromium.linux-x64
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Linux_x64?type=snapshots | grep -oP "\d{6,}") > src/chromium.linux-x64/readme.md
+
+          find ./src/*/*/locales/  -type f -name "*.pak" -not -name "en-US.pak" -delete
+          rm ./src/*/chrome-win/interactive_ui_tests.exe
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,18 @@ jobs:
           
           curl https://download-chromium.appspot.com/dl/Win_x64?type=snapshots -L -o obj/win-x64.zip
           unzip obj/win-x64.zip -d src/chromium.win-x64
-          rm ./src/chromium.win-x64/chrome-win/interactive_ui_tests.exe
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Win_x64?type=snapshots | grep -oP "\d{6,}") > src/chromium.win-x64/readme.md
 
           curl https://download-chromium.appspot.com/dl/Win?type=snapshots -L -o obj/win-x86.zip
           unzip obj/win-x86.zip -d src/chromium.win-x86
-          rm ./src/chromium.win-x86/chrome-win/interactive_ui_tests.exe
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Win?type=snapshots | grep -oP "\d{6,}") > src/chromium.win-x86/readme.md
 
           curl https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots -L -o obj/linux-x64.zip
           unzip obj/linux-x64.zip -d src/chromium.linux-x64
           echo Chromium build https://crrev.com/$(curl --silent https://download-chromium.appspot.com/rev/Linux_x64?type=snapshots | grep -oP "\d{6,}") > src/chromium.linux-x64/readme.md
+
+          find ./src/*/*/locales/  -type f -name "*.pak" -not -name "en-US.pak" -delete
+          rm ./src/*/chrome-win/interactive_ui_tests.exe
 
       - name: 🙏 build
         run: dotnet build -bl -p:version=${GITHUB_REF#refs/*/v}


### PR DESCRIPTION
For embedded or automated scenarios, this is enough and reduces the payload size significantly.

Fixes #97