### PR TITLE
fix: set artifact retention to 1 day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           name: pkg
           path: bin/*
+          retention-days: 1
 
   test:
     needs: build


### PR DESCRIPTION
Reduces Actions storage by setting artifact retention to 1 day. These artifacts are only used for inter-job artifact passing within the same workflow run and don't need to survive past run completion. Fixes storage quota exhaustion on the devlooped org.