### PR TITLE
fix: 1-day retention on publish nupkg artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-﻿# Builds a final release version and pushes to nuget.org 
+# Builds a final release version and pushes to nuget.org 
 # whenever a release is published.
 # Requires: secrets.NUGET_API_KEY
 
@@ -66,6 +66,7 @@ jobs:
         with:
           name: pkg
           path: bin/*
+          retention-days: 1
 
   test:
     needs: build


### PR DESCRIPTION
## Summary
- Add `retention-days: 1` to the `pkg` upload in `publish.yml`.
- PR/CI `build.yml` already uploads nupkgs with 1-day retention; this aligns release packaging.

Keeps large Chromium nupkgs (~767MB) from lingering 90 days in Actions storage.